### PR TITLE
Custom Cover UAT Low Priority Fixes Support

### DIFF
--- a/Sources/PryntTrimmerView/Parents/AVAssetTimeSelector.swift
+++ b/Sources/PryntTrimmerView/Parents/AVAssetTimeSelector.swift
@@ -58,6 +58,8 @@ public class AVAssetTimeSelector: UIView, UIScrollViewDelegate {
     func configureGestureRecognizers() {
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(singleTap(_:)))
         let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(longTap(_ :)))
+        tapGestureRecognizer.isEnabled = false
+        longPressGestureRecognizer.isEnabled = false
         longPressGestureRecognizer.minimumPressDuration = 0.1
         addGestureRecognizer(tapGestureRecognizer)
         addGestureRecognizer(longPressGestureRecognizer)

--- a/Sources/PryntTrimmerView/Parents/AVAssetTimeSelector.swift
+++ b/Sources/PryntTrimmerView/Parents/AVAssetTimeSelector.swift
@@ -26,6 +26,12 @@ public class AVAssetTimeSelector: UIView, UIScrollViewDelegate {
         }
     }
 
+    var tapGestureRecognizer: UIGestureRecognizer?
+
+    var longPressGestureRecognizer: UIGestureRecognizer?
+
+    var thumbSelectorTrackTappedHandler: ((CGPoint) -> Void)?
+
     /// The asset to be displayed in the underlying scroll view. Setting a new asset will automatically refresh the thumbnails.
     public var asset: AVAsset? {
         didSet {
@@ -46,6 +52,39 @@ public class AVAssetTimeSelector: UIView, UIScrollViewDelegate {
     func setupSubviews() {
         setupAssetPreview()
         constrainAssetPreview()
+        configureGestureRecognizers()
+    }
+
+    func configureGestureRecognizers() {
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(singleTap(_:)))
+        let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(longTap(_ :)))
+        longPressGestureRecognizer.minimumPressDuration = 0.1
+        addGestureRecognizer(tapGestureRecognizer)
+        addGestureRecognizer(longPressGestureRecognizer)
+        self.tapGestureRecognizer = tapGestureRecognizer
+        self.longPressGestureRecognizer = longPressGestureRecognizer
+    }
+
+    func enableGestureRecognizers() {
+        self.tapGestureRecognizer?.isEnabled = true
+        self.longPressGestureRecognizer?.isEnabled = true
+    }
+
+    func disableGestureRecognizers() {
+        self.tapGestureRecognizer?.isEnabled = false
+        self.longPressGestureRecognizer?.isEnabled = false
+    }
+
+    @objc
+    func longTap(_ recognizer: UILongPressGestureRecognizer) {
+        let location = recognizer.location(in: self)
+        thumbSelectorTrackTappedHandler?(location)
+    }
+
+    @objc
+    func singleTap(_ recognizer: UITapGestureRecognizer) {
+        let location = recognizer.location(in: self)
+        thumbSelectorTrackTappedHandler?(location)
     }
 
     public func regenerateThumbnails() {

--- a/Sources/PryntTrimmerView/Parents/AssetVideoScrollView.swift
+++ b/Sources/PryntTrimmerView/Parents/AssetVideoScrollView.swift
@@ -9,6 +9,10 @@
 import AVFoundation
 import UIKit
 
+protocol AssetVideoScrollViewDelegate: AnyObject {
+    func didUpdateThumbnails(to size: CGSize, for asset: AVAsset)
+}
+
 class AssetVideoScrollView: UIScrollView {
 
     private var widthConstraint: NSLayoutConstraint?
@@ -16,6 +20,8 @@ class AssetVideoScrollView: UIScrollView {
     let contentView = UIView()
     public var maxDuration: Double = 15
     private var generator: AVAssetImageGenerator?
+
+    weak var assetVideoDelegate: AssetVideoScrollViewDelegate?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -56,7 +62,7 @@ class AssetVideoScrollView: UIScrollView {
             print("Could not calculate the thumbnail size.")
             return
         }
-
+        assetVideoDelegate?.didUpdateThumbnails(to: thumbnailSize, for: asset)
         generator?.cancelAllCGImageGeneration()
         removeFormerThumbnails()
         let newContentSize = setContentSize(for: asset)

--- a/Sources/PryntTrimmerView/ThumbSelectorView.swift
+++ b/Sources/PryntTrimmerView/ThumbSelectorView.swift
@@ -46,6 +46,11 @@ public class ThumbSelectorView: AVAssetTimeSelector {
 
     public func clearThumbSelectorViewStartingFrame() {
         thumbView.image = nil
+        thumbBorderColor = .clear
+    }
+
+    public func resetThumbViewBorderColor(to color: UIColor = .white) {
+        thumbBorderColor = color
     }
 
     public func applyCustomThumbSelectorDimmingViewColor(_ color: UIColor) {

--- a/Sources/PryntTrimmerView/ThumbSelectorView.swift
+++ b/Sources/PryntTrimmerView/ThumbSelectorView.swift
@@ -36,12 +36,6 @@ public class ThumbSelectorView: AVAssetTimeSelector {
 
     public weak var delegate: ThumbSelectorViewDelegate?
 
-    /// When `true` the starting frame of the video will be selected upon loading the video asset.
-    public var shouldSelectStartingVideoFrame: Bool = true
-
-    /// The custom `UIColor` used for the thumb selector dimming view.
-    public var customThumbSelectorDimmingViewBackgroundColor: UIColor?
-
     // MARK: - View & constraints configurations
 
     override func setupSubviews() {
@@ -50,11 +44,19 @@ public class ThumbSelectorView: AVAssetTimeSelector {
         setupThumbView()
     }
 
+    public func clearThumbSelectorViewStartingFrame() {
+        thumbView.image = nil
+    }
+
+    public func applyCustomThumbSelectorDimmingViewColor(_ color: UIColor) {
+        dimmingView.backgroundColor = color
+    }
+
     private func setupDimmingView() {
 
         dimmingView.translatesAutoresizingMaskIntoConstraints = false
         dimmingView.isUserInteractionEnabled = false
-        dimmingView.backgroundColor = customThumbSelectorDimmingViewBackgroundColor ?? UIColor.white.withAlphaComponent(0.7)
+        dimmingView.backgroundColor = UIColor.white.withAlphaComponent(0.7)
         addSubview(dimmingView)
         dimmingView.leftAnchor.constraint(equalTo: leftAnchor).isActive = true
         dimmingView.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
@@ -118,9 +120,7 @@ public class ThumbSelectorView: AVAssetTimeSelector {
             setupThumbnailGenerator(with: asset)
             leftThumbConstraint?.constant = 0
             // Provide some property on the thumb selector to update selected time on asset change.
-            if shouldSelectStartingVideoFrame {
-                updateSelectedTime()
-            }
+            updateSelectedTime()
         }
         super.assetDidChange(newAsset: newAsset)
     }

--- a/Sources/PryntTrimmerView/ThumbSelectorView.swift
+++ b/Sources/PryntTrimmerView/ThumbSelectorView.swift
@@ -36,6 +36,8 @@ public class ThumbSelectorView: AVAssetTimeSelector {
 
     public weak var delegate: ThumbSelectorViewDelegate?
 
+    /// When `true` the starting frame of the video will be selected upon loading the video asset.
+    public var shouldSelectStartingVideoFrame: Bool = true
     // MARK: - View & constraints configurations
 
     override func setupSubviews() {
@@ -111,7 +113,10 @@ public class ThumbSelectorView: AVAssetTimeSelector {
         if let asset = newAsset {
             setupThumbnailGenerator(with: asset)
             leftThumbConstraint?.constant = 0
-            updateSelectedTime()
+            // Provide some property on the thumb selector to update selected time on asset change.
+            if shouldSelectStartingVideoFrame {
+                updateSelectedTime()
+            }
         }
         super.assetDidChange(newAsset: newAsset)
     }

--- a/Sources/PryntTrimmerView/ThumbSelectorView.swift
+++ b/Sources/PryntTrimmerView/ThumbSelectorView.swift
@@ -200,10 +200,12 @@ public class ThumbSelectorView: AVAssetTimeSelector {
 extension ThumbSelectorView: AssetVideoScrollViewDelegate {
 
     func didUpdateThumbnails(to size: CGSize, for asset: AVAsset) {
+        thumbViewWidthConstraint?.isActive = false
         if size.width < size.height {
-            thumbViewWidthConstraint?.isActive = false
             thumbViewWidthConstraint = thumbView.widthAnchor.constraint(equalToConstant: size.width)
-            thumbViewWidthConstraint?.isActive = true
+        } else {
+            thumbViewWidthConstraint = thumbView.widthAnchor.constraint(equalTo: thumbView.heightAnchor)
         }
+        thumbViewWidthConstraint?.isActive = true
     }
 }

--- a/Sources/PryntTrimmerView/ThumbSelectorView.swift
+++ b/Sources/PryntTrimmerView/ThumbSelectorView.swift
@@ -36,6 +36,8 @@ public class ThumbSelectorView: AVAssetTimeSelector {
 
     public weak var delegate: ThumbSelectorViewDelegate?
 
+    private(set) var thumbViewWidthConstraint: NSLayoutConstraint?
+
     // MARK: - View & constraints configurations
 
     override func setupSubviews() {
@@ -81,10 +83,12 @@ public class ThumbSelectorView: AVAssetTimeSelector {
 
         leftThumbConstraint = thumbView.leftAnchor.constraint(equalTo: leftAnchor)
         leftThumbConstraint?.isActive = true
-        thumbView.widthAnchor.constraint(equalTo: thumbView.heightAnchor).isActive = true
+        thumbViewWidthConstraint = thumbView.widthAnchor.constraint(equalTo: thumbView.heightAnchor)
+        thumbViewWidthConstraint?.isActive = true
         thumbView.heightAnchor.constraint(equalTo: heightAnchor).isActive = true
         thumbView.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
 
+        assetPreview.assetVideoDelegate = self
         let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(ThumbSelectorView.handlePanGesture(_:)))
         thumbView.addGestureRecognizer(panGestureRecognizer)
     }
@@ -188,5 +192,16 @@ public class ThumbSelectorView: AVAssetTimeSelector {
 
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         updateSelectedTime()
+    }
+}
+
+// MARK: - AssetVideoScrollViewDelegate Conformance
+
+extension ThumbSelectorView: AssetVideoScrollViewDelegate {
+
+    func didUpdateThumbnails(to size: CGSize, for asset: AVAsset) {
+        thumbViewWidthConstraint?.isActive = false
+        thumbViewWidthConstraint = thumbView.widthAnchor.constraint(equalToConstant: size.width)
+        thumbViewWidthConstraint?.isActive = true
     }
 }

--- a/Sources/PryntTrimmerView/ThumbSelectorView.swift
+++ b/Sources/PryntTrimmerView/ThumbSelectorView.swift
@@ -129,7 +129,6 @@ public class ThumbSelectorView: AVAssetTimeSelector {
         if let asset = newAsset {
             setupThumbnailGenerator(with: asset)
             leftThumbConstraint?.constant = 0
-            // Provide some property on the thumb selector to update selected time on asset change.
             updateSelectedTime()
         }
         super.assetDidChange(newAsset: newAsset)

--- a/Sources/PryntTrimmerView/ThumbSelectorView.swift
+++ b/Sources/PryntTrimmerView/ThumbSelectorView.swift
@@ -44,9 +44,21 @@ public class ThumbSelectorView: AVAssetTimeSelector {
         super.setupSubviews()
         setupDimmingView()
         setupThumbView()
+        thumbSelectorTrackTappedHandler = { [weak self] location in
+            guard let self = self,
+                  let time = self.getTime(from: location.x) else {
+                return
+            }
+            self.disableGestureRecognizers()
+            self.resetThumbViewBorderColor()
+            self.generateThumbnailImage(for: time)
+            let width = self.thumbView.frame.size.width / 2
+            self.leftThumbConstraint?.constant = location.x - width
+        }
     }
 
     public func clearThumbSelectorViewStartingFrame() {
+        enableGestureRecognizers()
         thumbView.image = nil
         thumbBorderColor = .clear
     }

--- a/Sources/PryntTrimmerView/ThumbSelectorView.swift
+++ b/Sources/PryntTrimmerView/ThumbSelectorView.swift
@@ -200,8 +200,10 @@ public class ThumbSelectorView: AVAssetTimeSelector {
 extension ThumbSelectorView: AssetVideoScrollViewDelegate {
 
     func didUpdateThumbnails(to size: CGSize, for asset: AVAsset) {
-        thumbViewWidthConstraint?.isActive = false
-        thumbViewWidthConstraint = thumbView.widthAnchor.constraint(equalToConstant: size.width)
-        thumbViewWidthConstraint?.isActive = true
+        if size.width < size.height {
+            thumbViewWidthConstraint?.isActive = false
+            thumbViewWidthConstraint = thumbView.widthAnchor.constraint(equalToConstant: size.width)
+            thumbViewWidthConstraint?.isActive = true
+        }
     }
 }

--- a/Sources/PryntTrimmerView/ThumbSelectorView.swift
+++ b/Sources/PryntTrimmerView/ThumbSelectorView.swift
@@ -54,7 +54,9 @@ public class ThumbSelectorView: AVAssetTimeSelector {
             self.updateSelectedTime()
         }
     }
-
+    /// Clears the thumb view image and sets the thumb border color to clear. This also has a side effect of enabling
+    /// gesture recognizers that will listen for taps on the cover selector to enable cover selection again if a user taps
+    /// anywhere in the view.
     public func clearThumbSelectorViewStartingFrame() {
         enableGestureRecognizers()
         thumbView.image = nil

--- a/Sources/PryntTrimmerView/ThumbSelectorView.swift
+++ b/Sources/PryntTrimmerView/ThumbSelectorView.swift
@@ -45,15 +45,13 @@ public class ThumbSelectorView: AVAssetTimeSelector {
         setupDimmingView()
         setupThumbView()
         thumbSelectorTrackTappedHandler = { [weak self] location in
-            guard let self = self,
-                  let time = self.getTime(from: location.x) else {
-                return
-            }
+            guard let self = self else  { return }
             self.disableGestureRecognizers()
             self.resetThumbViewBorderColor()
-            self.generateThumbnailImage(for: time)
             let width = self.thumbView.frame.size.width / 2
             self.leftThumbConstraint?.constant = location.x - width
+            self.layoutIfNeeded()
+            self.updateSelectedTime()
         }
     }
 

--- a/Sources/PryntTrimmerView/ThumbSelectorView.swift
+++ b/Sources/PryntTrimmerView/ThumbSelectorView.swift
@@ -75,6 +75,7 @@ public class ThumbSelectorView: AVAssetTimeSelector {
 
         thumbView.translatesAutoresizingMaskIntoConstraints = false
         thumbView.layer.borderWidth = 2.0
+        thumbView.layer.cornerRadius = 4.0
         thumbView.layer.borderColor = thumbBorderColor.cgColor
         thumbView.isUserInteractionEnabled = true
         thumbView.contentMode = .scaleAspectFill

--- a/Sources/PryntTrimmerView/ThumbSelectorView.swift
+++ b/Sources/PryntTrimmerView/ThumbSelectorView.swift
@@ -38,6 +38,10 @@ public class ThumbSelectorView: AVAssetTimeSelector {
 
     /// When `true` the starting frame of the video will be selected upon loading the video asset.
     public var shouldSelectStartingVideoFrame: Bool = true
+
+    /// The custom `UIColor` used for the thumb selector dimming view.
+    public var customThumbSelectorDimmingViewBackgroundColor: UIColor?
+
     // MARK: - View & constraints configurations
 
     override func setupSubviews() {
@@ -50,7 +54,7 @@ public class ThumbSelectorView: AVAssetTimeSelector {
 
         dimmingView.translatesAutoresizingMaskIntoConstraints = false
         dimmingView.isUserInteractionEnabled = false
-        dimmingView.backgroundColor = UIColor.white.withAlphaComponent(0.7)
+        dimmingView.backgroundColor = customThumbSelectorDimmingViewBackgroundColor ?? UIColor.white.withAlphaComponent(0.7)
         addSubview(dimmingView)
         dimmingView.leftAnchor.constraint(equalTo: leftAnchor).isActive = true
         dimmingView.rightAnchor.constraint(equalTo: rightAnchor).isActive = true


### PR DESCRIPTION
Supporting PR for custom video cover upload which includes support for: 

- Provide `AssetVideoScrollViewDelegate` to communicate when the thumbnail size of the video frames in the thumb selector view has changed (when the asset is initially loaded)
- Add logic in `ThumbSelectorView` to modify the width constraint of the sliding thumb view based on thumbnail size.
- Rounds the corners of the `ThumbSelectorView` to match latest Figma designs. 
- Exposes public methods to clear and reset the color on the `ThumbSelectorView` and dimming view as well as apply a custom color.